### PR TITLE
Upstream PR for ferror investigation..

### DIFF
--- a/configuration.h
+++ b/configuration.h
@@ -2,7 +2,7 @@
 #define CONFIGURATION_H
 
 #define PRU_BASEFREQ    	40000           // PRU Base thread ISR update frequency (hz)
-#define PRU_SERVOFREQ       200            // PRU Servo thread ISR update freqency (hz)
+#define PRU_SERVOFREQ       3000            // PRU Servo thread ISR update freqency (hz)
 
 #define BASE_SLICE          0               // RP2040 PWM Slice used by the Base thread
 #define SERVO_SLICE         1               // RP2040 PWM Slice used by the Servo thread
@@ -28,7 +28,7 @@
 // Data buffer configuration
 #define BUFFER_SIZE 		68            	// Size of recieve buffer - same as HAL component, 64
 
-#define PLL_SYS_KHZ (125 * 1000)    // 125MHz
+#define PLL_SYS_KHZ (133 * 1000)    // 133MHz
 #define SOCKET_MACRAW 0
 #define PORT_LWIPERF 5001
 

--- a/port/ioLibrary_Driver/src/w5x00_spi.c
+++ b/port/ioLibrary_Driver/src/w5x00_spi.c
@@ -137,8 +137,8 @@ static void wizchip_critical_section_unlock(void)
 
 void wizchip_spi_initialize(void)
 {
-    // this example will use SPI0 at 5MHz
-    spi_init(SPI_PORT, 5000 * 1000);
+    // this example will use SPI0 at 40MHz
+    spi_init(SPI_PORT, 50000 * 1000);
 
     gpio_set_function(PIN_SCK, GPIO_FUNC_SPI);
     gpio_set_function(PIN_MOSI, GPIO_FUNC_SPI);

--- a/thread/pruThread.cpp
+++ b/thread/pruThread.cpp
@@ -42,6 +42,7 @@ void pruThread::registerModulePost(Module* module)
 
 void pruThread::run(void)
 {
+	while (this->semaphore == true);	
 	this->semaphore = true;
 
 	// iterate over the Thread pointer vector to run all instances of Module::runModule()


### PR DESCRIPTION
Few things I have found:

First, I am not sure that the existing semaphore made the memory access completely atomic. I made some changes there and in the thread code to ensure that when a packet arrives, the threads cannot interrupt the data copying until the UDP callback releases the semaphore.  This will add some jitter, but I'm not sure this is avoidable.  I also disabled interrupts during the data copy for the same reason.  As things evolve I'll try to take some jitter measurements

SPI frequency was pretty low.  PicoBOB is fairly tight and I have had no issues running the SPI at 50 MHz.  This really helps the ping times.

I found that oversampling the servo thread on the PRU really helps.  I am not completely clear on why this is, but I think it is because of clock drift.  As there is no synchronization mechanism between the two boards, it seemed to me that they would go in and out of sync with following errors worsening and improving with nothing else changing.  Oversampling the servo thread seems to have fixed this in my testing and it makes sense to me as there will no longer be points where the servo thread on the PRU will 'miss' a packet from the host.

Not sure if this all makes sense to you, but it is night and day different on my bench.  These settings are stable with even 1-2 ms servo thread in LinuxCNC in my testing with a pi400.  I am still getting up to speed on LinuxCNC so maybe I am missing something on that side.